### PR TITLE
Add BookOutlet.com (US) site support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Find what books from your Goodreads to-read list are available on BookOutlet - n
 
 ## Overview
 
-This tool helps you find deals on books from your Goodreads to-read shelf by searching BookOutlet.ca. It features:
+This tool helps you find deals on books from your Goodreads to-read shelf by searching BookOutlet (Canadian or US site). It features:
 
 1. **ISBN-based exact matching** for perfect accuracy
 2. **Advanced fuzzy matching** with carefully tuned algorithms
@@ -97,6 +97,16 @@ python run.py --format text
 python run.py --parallel true --workers 10
 ```
 
+**Search US BookOutlet site:**
+```bash
+# Use CLI argument
+python run.py --site com
+
+# Or edit config.yaml
+# search:
+#   site: "com"
+```
+
 ## Configuration
 
 ### Using config.yaml
@@ -104,6 +114,10 @@ python run.py --parallel true --workers 10
 Create a `config.yaml` file to save your preferences:
 
 ```yaml
+# Search settings
+search:
+  site: "ca"  # Options: "ca" (Canada), "com" (US)
+
 # Input settings
 input:
   csv_path: "goodreads_library_export.csv"
@@ -147,6 +161,7 @@ python run.py --help
 
 | Argument | Description | Default |
 |----------|-------------|---------|
+| `--site` | BookOutlet site: ca (Canada), com (US) | `ca` |
 | `--config` | Path to config YAML file | `config.yaml` |
 | `--csv` | Path to Goodreads CSV export | `goodreads_library_export.csv` |
 | `--output` | Output file path (extension auto-added) | `output` |
@@ -407,7 +422,7 @@ bookoutlet-goodreads/
 
 ## Known Limitations
 
-1. **Only searches BookOutlet.ca** (Canadian site)
+1. **Single site per search** (cannot search both .ca and .com simultaneously)
 2. **No price tracking** over time
 3. **No automatic purchasing** or wishlist integration
 4. **Sequential HTML parsing** (parallel search, sequential parse)
@@ -416,12 +431,12 @@ bookoutlet-goodreads/
 ## Contributing
 
 Contributions welcome! Areas for improvement:
-- Add support for bookoutlet.com (US site)
+- Add support for searching both .ca and .com sites simultaneously
+- Support for other bookstores (AbeBooks, ThriftBooks, etc.)
 - Implement price tracking database
 - Add browser extension
 - Web UI with live updates
 - Better ISBN extraction from BookOutlet
-- Support for other bookstores
 
 ## License
 

--- a/bookoutlet_goodreads/config/schema.py
+++ b/bookoutlet_goodreads/config/schema.py
@@ -56,6 +56,11 @@ class DisplayConfig(BaseModel):
     verbose: bool = Field(default=False)
 
 
+class SearchConfig(BaseModel):
+    """Search configuration."""
+    site: Literal["ca", "com"] = Field(default="ca", description="BookOutlet site: ca (Canada) or com (US)")
+
+
 class Config(BaseModel):
     """Main configuration model."""
     input: InputConfig = Field(default_factory=InputConfig)
@@ -63,3 +68,4 @@ class Config(BaseModel):
     matching: MatchingConfig = Field(default_factory=MatchingConfig)
     parallel: ParallelConfig = Field(default_factory=ParallelConfig)
     display: DisplayConfig = Field(default_factory=DisplayConfig)
+    search: SearchConfig = Field(default_factory=SearchConfig)

--- a/bookoutlet_goodreads/search/scraper.py
+++ b/bookoutlet_goodreads/search/scraper.py
@@ -469,9 +469,13 @@ class Scraper:
 
 
 class BookOutletSearch(Scraper):
-    def __init__(self, titles: List[str], fuzz_thresh: int = 90, book_data: List[Dict] = None, require_author_match: bool = False):
+    def __init__(self, titles: List[str], fuzz_thresh: int = 90, book_data: List[Dict] = None, require_author_match: bool = False, site: str = "ca"):
         super().__init__(titles, fuzz_thresh=fuzz_thresh, book_data=book_data, require_author_match=require_author_match)
-        self.base_url = "https://bookoutlet.ca/browse?"
+
+        # Domain mapping
+        domain = "bookoutlet.ca" if site == "ca" else "bookoutlet.com"
+        self.base_url = f"https://{domain}/browse?"
+        self.domain = domain  # Store for URL construction
 
     def parse_books(self, response: str) -> List[Dict]:
         """
@@ -499,7 +503,7 @@ class BookOutletSearch(Scraper):
                 href = link.get('href', '')
                 if href:
                     if href.startswith('/'):
-                        book_info['url'] = 'https://bookoutlet.ca' + href
+                        book_info['url'] = f'https://{self.domain}' + href
                     else:
                         book_info['url'] = href
 
@@ -568,7 +572,7 @@ class BookOutletSearch(Scraper):
                     src = img_tag.get('src', '')
                     # Make absolute URL if needed
                     if src.startswith('/'):
-                        book_info['cover_url'] = 'https://bookoutlet.ca' + src
+                        book_info['cover_url'] = f'https://{self.domain}' + src
                     else:
                         book_info['cover_url'] = src
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,9 @@
 # BookOutlet-Goodreads Matcher Configuration
 
+# Search settings
+search:
+  site: "ca"  # Options: "ca" (Canada), "com" (US)
+
 # Input settings
 input:
   csv_path: "goodreads_library_export.csv"

--- a/run.py
+++ b/run.py
@@ -60,7 +60,8 @@ def main(config_path=None, cli_overrides=None):
         titles,
         fuzz_thresh=config.matching.threshold,
         book_data=book_data,
-        require_author_match=config.matching.require_author_match
+        require_author_match=config.matching.require_author_match,
+        site=config.search.site
     )
 
     # Search with optional parallel processing
@@ -193,6 +194,13 @@ def parse_args():
         action="store_true"
     )
 
+    parser.add_argument(
+        "--site",
+        help="BookOutlet site: ca (Canada) or com (US)",
+        choices=['ca', 'com'],
+        default=None
+    )
+
     return parser.parse_args()
 
 
@@ -222,6 +230,9 @@ if __name__ == "__main__":
 
     if args.no_progress:
         cli_overrides.setdefault('display', {})['show_progress'] = False
+
+    if args.site:
+        cli_overrides.setdefault('search', {})['site'] = args.site
 
     # Run main with configuration
     main(config_path=args.config, cli_overrides=cli_overrides)


### PR DESCRIPTION
Enable users to search both Canadian and US BookOutlet sites for book deals. This expands the tool's reach to US users and allows price comparison between regions.

Changes:
- Add site selection to configuration (search.site: "ca" or "com")
- Add --site CLI argument for easy site switching
- Implement dynamic domain mapping in BookOutletSearch class
- Update all URL constructions to use configurable domain
- Add Pydantic validation for site parameter
- Update documentation with usage examples

The implementation maintains backward compatibility by defaulting to the Canadian site. Both sites use identical HTML structure, confirmed through live testing.